### PR TITLE
[Codespell] Skip composer.lock and pnpm-lock.yaml

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # Run codespell
           rm -rf b && cp -a a b && cd b
-          codespell -L invokable --check-filenames -w || true
+          codespell -L invokable --check-filenames -w --skip=composer.lock,pnpm-lock.yaml || true
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then


### PR DESCRIPTION
On UX we have false positives where Fabbot, through Codespell, reports spelling issues on lockfiles. 

Since there files are auto-generated, let's skip them.