### PR TITLE
Exclude `*.xlf` files from codespell

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # Run codespell
           rm -rf b && cp -a a b && cd b
-          codespell -L invokable --check-filenames -w --skip=composer.lock,pnpm-lock.yaml || true
+          codespell -L invokable --check-filenames -w --skip='composer.lock,pnpm-lock.yaml,*.xlf' || true
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then


### PR DESCRIPTION
`codespell` finds false-positive issues in non-English translation files.

https://github.com/symfony/symfony/actions/runs/17576974024/job/49924365640?pr=61700#step:5:25
