### PR TITLE
Run Twig-CS-Fixer if config file exists

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Check Twig code style
-        if: always()
+        if: always() && hashFiles('o/.twig-cs-fixer.dist.php') != ''
         run: |
           # Run Twig-CS-Fixer
           rm -rf b && cp -a a b && cd b


### PR DESCRIPTION
Follow https://github.com/symfony-tools/fabbot/pull/12#discussion_r2659519952, Fabbot runs on symfony/symfony but it could fails on branches <7.4, since it has no Twig-CS-Fixer configuration file.
