### PR TITLE
Add check for commit attribution

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -129,6 +129,20 @@ jobs:
               exit 1
             } || true
 
+      - name: Check commit attribution
+        if: always()
+        env:
+          REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Commits must be linked to a GitHub account
+          gh api --paginate "/repos/$REPO/pulls/$PR/commits" \
+            | jq -r '.[] | select(.author.login == null and (.commit.author.email | test("@users\\.noreply\\.github\\.com$") | not)) | "::error::Commit \(.sha[0:7]) uses email \(.commit.author.email), which is not linked to a GitHub account."' \
+            | grep "::error::" && {
+              echo "Please configure your git email to match your GitHub account."
+              exit 1
+            } || true
+
       - name: Check test-case methods
         if: always()
         run: |


### PR DESCRIPTION
## Adds check for commit attribution.

have witnessed contributors committing with their corporate/ghost emails e.g. ([63022](https://github.com/symfony/symfony/pull/63022), [#49002](https://github.com/symfony/symfony/pull/49002#issuecomment-1385827253), [#49138](https://github.com/symfony/symfony/pull/49138#issuecomment-1407318621), [63781](https://github.com/symfony/symfony/pull/63781#issuecomment-4137580507)).

This check should call the authors to go back and fix it.

> Commit abc1234 uses email foo@bar.com, which is not linked to a GitHub account.
> Please configure your git email to match your GitHub account.