### PR TITLE
Keep codespell config

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -36,6 +36,7 @@ jobs:
           mkdir a
           [ -e o/.php-cs-fixer.dist.php ] && cp -a {o,a}/.php-cs-fixer.dist.php
           [ -e o/.twig-cs-fixer.dist.php ] && cp -a {o,a}/.twig-cs-fixer.dist.php
+          [ -e o/.codespellrc ] && cp -a {o,a}/.codespellrc
 
           gh api --paginate "/repos/$REPO/pulls/$PR/files" \
             | jq -rc '.[] | select(.status != "removed") | .filename' \


### PR DESCRIPTION
I'm trying to find out why our `.codespellrc` in symfony/ai doesn't work - and if i get it right, it's just not around in folder a/b. this would also enable us to keep project specific details like `*/Symfony/Component/Intl/Resources/data/*'` out of fabbot

see
* https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file
* https://github.com/symfony/ai/blob/main/.codespellrc
* https://github.com/symfony/ai/actions/runs/24011606954/job/70024014267?pr=1876
