### PR TITLE
Upload the patches as an artifact to ease applying them

### DIFF
--- a/.github/workflows/fabbot.yml
+++ b/.github/workflows/fabbot.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
+  PATCH_DIR: ${{ github.workspace }}/patches
 
 jobs:
   check:
@@ -37,7 +38,7 @@ jobs:
           pip install codespell &
           composer global require -q friendsofphp/php-cs-fixer:^3 seld/jsonlint symfony/yaml vincentlanglet/twig-cs-fixer:^3 &
 
-          mkdir a
+          mkdir a "$PATCH_DIR"
           [ -e o/.php-cs-fixer.dist.php ] && cp -a {o,a}/.php-cs-fixer.dist.php
           [ -e o/.twig-cs-fixer.dist.php ] && cp -a {o,a}/.twig-cs-fixer.dist.php
           [ -e o/.codespellrc ] && cp -a {o,a}/.codespellrc
@@ -60,6 +61,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/php-cs-fixer.diff" || true
             echo "::error::PHP-CS-Fixer found style issues. Please apply the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -77,6 +79,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/twig-cs-fixer.diff" || true
             echo "::error::Twig-CS-Fixer found style issues. Please apply the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -94,6 +97,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/codespell.diff" || true
             echo "::error::PHP-CS-Fixer found typos. Please apply the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -111,6 +115,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/readonly-classes.diff" || true
             echo "::error::Readonly classes should be replaced by readonly properties."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -160,6 +165,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/test-case-methods.diff" || true
             echo "::error::Test case methods should not have a return type. Please apply the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -180,6 +186,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/deprecated-annotations.diff" || true
             echo "::error::@deprecated annotations should mention ${{ inputs.package }}. Please apply the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -286,6 +293,7 @@ jobs:
           cd ..
 
           if ! diff -qr --no-dereference a/ b/ >/dev/null; then
+            diff -pru2 --no-dereference a/ b/ > "$PATCH_DIR/exception-messages.diff" || true
             echo "::error::Some exception messages might need a tweak. Please consider the patch below."
             echo -e "\n \n git apply - <<'EOF_PATCH'"
             diff -pru2 --no-dereference --color=always a/ b/ || true
@@ -317,6 +325,23 @@ jobs:
             rm PROBLEM_FILES
             exit 1
           fi
+
+      - name: Upload the patches
+        id: patches
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fabbot-patch
+          path: ${{ env.PATCH_DIR }}/*.diff
+          if-no-files-found: ignore
+          retention-days: 5
+
+      - name: Explain how to apply the patches
+        if: always() && steps.patches.outputs.artifact-id != ''
+        run: |
+          # Point to the patches instead of making people select them from the logs
+          echo "::notice::Instead of copy/pasting the patches above, you can download and apply them all at once:"
+          echo -e "\n \n gh run download ${{ github.run_id }} -R ${{ github.repository }} -n fabbot-patch -D fabbot-patch && git apply -v fabbot-patch/*.diff\n \n"
 
       - name: 🧠 Fabbot can generate false-positives. Cherry-pick as fits 🍒. Reviewers will help.
         if: always()


### PR DESCRIPTION
Fixes #16.

Long patches are tedious to select from the logs, so this uploads them as an artifact and prints a ready-to-run command:

```
gh run download <run_id> -R <repo> -n fabbot-patch -D fabbot-patch && git apply -v fabbot-patch/*.diff
```

The `curl -L <artifact-url> | git apply` suggested in the issue can't work, unfortunately: artifacts require authentication even on public repos (anonymously the artifact URL gives a `404` and the API a `401`), and `upload-artifact` always zips its payload. `gh` handles both the auth and the unzipping, and it's already a hard requirement of this workflow anyway.

**Nothing changes for the current output.** Each of the 7 patch-producing checks keeps printing its inline colored patch exactly as before, and just writes an additional uncolored copy to `$PATCH_DIR`. The uncolored copy is not redundant: a `--color=always` diff carries ANSI escapes and `git apply` rejects it outright (`error: No valid patches in input`), so it makes a fine thing to read but a poor thing to apply.

The artifact is only uploaded when there is something to apply (`if-no-files-found: ignore`), so green runs are unaffected.

Two things worth knowing:

- When several checks fail, you get one `.diff` per check, all computed against the same base. If two of them touch the same lines, applying them in one go can conflict — same as copy/pasting both patches today, just more visible.
- `PATCH_DIR` uses `github.workspace` rather than `runner.temp`, because the `runner` context isn't available in a workflow-level `env`. It sits outside `a/` and `b/`, so no check sees it.

**Where I hit my limit:** I verified locally that the uncolored diff is generated and applies cleanly with `git apply` (and that the colored one doesn't), but I could not exercise the artifact upload / `gh run download` round-trip — that needs a real Actions run on a repo calling this reusable workflow, which I couldn't reproduce faithfully. So the mechanism looks sound to me, but consider it unproven end-to-end, and I'd rather say so than pretend otherwise. Happy to iterate if a real run tells a different story, and happy to close if you'd rather keep the logs as the single source of truth.
